### PR TITLE
new flash controller, mosi working

### DIFF
--- a/rtl/src/spi_master_fl.v
+++ b/rtl/src/spi_master_fl.v
@@ -1,0 +1,106 @@
+
+`timescale 1ns / 1ps
+`define SPI_DATA_W 8
+`define SPI_COM_W 8
+`define SPI_ADDR_W 24
+
+module spi_master_fl(
+	
+	//CONTROLLER INTERFACE
+	input		clk,
+	input 		rst,
+
+	//CONTROLLER FROM CPU
+	input [`SPI_DATA_W-1:0]				data_in,
+	output reg [`SPI_DATA_W-1:0]		data_out,
+	input [`SPI_ADDR_W-1:0]				address,
+	input [`SPI_COM_W-1:0]				command,
+	input 								validflag,
+	output reg							tready,
+
+	//SPI INTERFACE
+	output  	sclk,
+	output reg	ss,
+	output reg	mosi,
+	input		miso
+);
+
+	//Register TX data, address, command
+	reg [`SPI_DATA_W-1:0]	r_datain;
+	reg [`SPI_ADDR_W-1:0]	r_address;
+	reg [`SPI_COM_W-1:0]	r_command;
+
+	//MOSI controller signals
+	reg 		r_mosiready;
+	reg 		r_mosibusy;
+	reg [4:0]	r_mosicounter;
+	wire [31:0]	str2send;
+
+	//CLK generation signals
+	reg [3:0] clk_counter = 4'd0;
+	parameter DIVISOR = 4'd2;
+	
+	//Generate sclk by clock division
+	always @(posedge clk) begin //rst block ?
+		clk_counter <= clk_counter + 4'd1;
+		if(clk_counter >= (DIVISOR-1)) begin
+			clk_counter <= 4'd0;
+		end
+	end
+	assign sclk = (clk_counter<DIVISOR/2)?1'b0:1'b1;
+	
+	//Receive data to transfer from upperlevel controller
+	always @(posedge clk, posedge rst) begin
+		if (rst) begin
+			r_datain <= `SPI_DATA_W'b0;
+			r_address <= `SPI_ADDR_W'b0;
+			r_command <= `SPI_COM_W'b0;
+		end else begin
+			if (validflag) begin
+				r_datain <= data_in;
+				r_address <= address;
+				r_command <= command;
+				r_mosiready <= 1'b1;
+			end
+		end
+	end
+	
+	//MOSI 
+	assign str2send = {r_command, r_address};
+	//Send a byte through mosi line
+	always @(negedge sclk, posedge rst) begin
+		if (rst) begin
+			ss <= 1'b1;	
+			r_mosiready <= 1'b0;
+			r_mosibusy <= 1'b0;
+			r_mosicounter <= 5'd31;
+		end else begin
+			if (r_mosiready | r_mosibusy) begin
+				//Drive ss low to start transaction
+				ss <= 1'b0;
+				r_mosibusy <= 1'b1;
+				r_mosiready <= 1'b0;
+
+				if(r_mosibusy) begin//one-cycle delay
+					mosi <= str2send[r_mosicounter];
+					r_mosicounter <= r_mosicounter - 5'd1;
+					if (r_mosicounter == 5'd0) begin
+						r_mosibusy <= 1'b0;
+					//	ss <= 1'b1;
+					end
+				end
+			end else begin
+				ss <= 1'b1;
+			end
+		end
+	end
+	
+	//MISO
+	//TODO keep ss low
+	/*always @(posedge sclk, posedge rst) begin
+		if (rst) begin
+		end else if
+			miso <= ;
+		end
+	end*/
+endmodule

--- a/rtl/testbench/spi_fl_tb.v
+++ b/rtl/testbench/spi_fl_tb.v
@@ -1,0 +1,76 @@
+`timescale 1ns / 1 ps
+
+module spi_tb;
+	
+	parameter clk_per = 20;
+
+	reg rst;
+	reg clk;
+
+	wire miso;
+	wire mosi;
+	wire ss;
+	wire sclk;
+	
+	reg [7:0] data_in;
+	wire [7:0] data_out;
+	reg [23:0] address;
+	reg [7:0] command;
+	reg validflag; //check later
+	wire tready;
+
+	//Controller signals
+	
+	// UUT Instantiation
+	spi_master_fl spi_m (
+			.clk		(clk),
+			.rst		(rst),
+
+			//SPI
+			.ss			(ss),
+			.mosi		(mosi),
+			.sclk		(sclk),
+			.miso		(miso),
+			
+			//Controller
+			.data_in	(data_in),
+			.data_out	(data_out),
+			.address	(address),
+			.command	(command),
+			.validflag	(validflag),
+			.tready		(tready)
+			);
+			
+
+	//Process
+	initial begin
+		$dumpfile("spi_fl_tb.vcd");
+		$dumpvars();
+		
+		//Clks and reset
+		rst = 1;
+		clk = 1;
+
+		//Deassert rst
+		#(4*clk_per+1) rst = 0;
+
+	end
+
+	//Master Process
+	initial begin
+		#100
+		data_in=8'hFC;
+		command=8'h55;
+		address=24'h555555;
+
+		#50
+		validflag=1'b1;
+		#20
+		validflag=1'b0;
+		#1500 $finish;
+	end
+
+	//CLK driving
+	always
+		#(clk_per/2) clk=~clk;
+endmodule


### PR DESCRIPTION
New spi flash controller
Assuming only 2 flash operations for now: READ and WRITE (PROGRAM in datasheets)
The controller receives the data to be sent on mosi, the address (3 bytes on datasheet) and the command (2 bytes)
Assuming can only transmit 1 byte at a time (data_in 1 byte)
The board supported flash memories support many other types of usually faster READ and WRITE operations 