### PR TITLE
Add `iob_linux_device_drivers` sw_module

### DIFF
--- a/iob_spi_master.py
+++ b/iob_spi_master.py
@@ -262,6 +262,12 @@ def setup(py_params_dict):
                 "instantiate": False,
             },
         ],
+        "sw_modules": [
+            # Software modules
+            {
+                "core_name": "iob_linux_device_drivers",
+            },
+        ],
         "snippets": [
             {
                 "verilog_code": """


### PR DESCRIPTION
This module will automatically generate Linux related files for this peripheral.
Related to https://github.com/IObundle/py2hwsw/pull/425